### PR TITLE
Bump versions to force update

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -12,7 +12,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70007;
+static const int PROTOCOL_VERSION = 70008;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -21,8 +21,8 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 70000;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70006;
-static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70007;
+static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70007;
+static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70008;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
Update the minimum versions allowed in the app, so that older nodes are disconnected. 
This ensures all nodes have the same collateral  and reward values.